### PR TITLE
Get all delivered raw data.

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -306,6 +306,12 @@ double Driver::waitResponseDouble(string const &command)
     return usblParser.getDouble(waitResponseString(command));
 }
 
+// Wait for a integer (that may be very long) response.
+long long unsigned int Driver::waitResponseULLongInt(string const &command)
+{
+    return usblParser.getULLongInt(waitResponseString(command));
+}
+
 // Wait for string response.
 string Driver::waitResponseString(string const &command)
 {
@@ -1024,6 +1030,14 @@ int Driver::getChannelNumber(void)
     return waitResponseInt(command);
 }
 
+// Get overall delivered raw data
+long long unsigned int Driver::getRawDataDeliveryCounter(void)
+{
+    string command = "AT?ZE";
+    sendCommand(command);
+    return waitResponseULLongInt(command);
+}
+
 // Set System Time for current time
 void Driver::setSystemTimeNow(void)
 {
@@ -1085,6 +1099,7 @@ AcousticChannel Driver::getAcousticChannelparameters(void)
     channel.channelNumber = getChannelNumber();
     channel.dropCount = getDropCounter();
     channel.overflowCounter = getOverflowCounter();
+    channel.delivered_raw_data = getRawDataDeliveryCounter();
     return channel;
 }
 

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -143,6 +143,13 @@ public:
      */
     double waitResponseDouble(string const &command);
 
+    /** Wait for a integer (that may be very long) response.
+     *
+     * @param command sent to device.
+     * @return long long unsigned integer requested.
+     */
+    long long unsigned int waitResponseULLongInt(string const &command);
+
     /** Wait for string response.
      *
      * @param command sent to device.
@@ -570,6 +577,13 @@ public:
     * @return value in bytes
     */
    int getChannelNumber(void);
+
+   /** Get overall delivered raw data
+    *
+    * Usbl documentation doesn't say the max size neither a way to reset it, so a ullong_int was chosen.
+    * @return counter of raw data bytes delivered to remote device.
+    */
+   long long unsigned int getRawDataDeliveryCounter(void);
 
    /** Set System Time for current time
     *

--- a/src/DriverTypes.hpp
+++ b/src/DriverTypes.hpp
@@ -273,7 +273,6 @@ struct AcousticConnection
 
     // Free transmission buffer space (in bytes)
     std::vector<int> freeBuffer;
-
 };
 
 /** Major device settings
@@ -380,6 +379,8 @@ struct MultiPath
  */
 struct AcousticChannel
 {
+    base::Time time;
+
     // Channel of current input-output interface
     // Data transferring among different channel is impossible.
     // 0..7
@@ -415,7 +416,13 @@ struct AcousticChannel
 
     std::vector<MultiPath> multiPath;
 
-    base::Time time;
+    // Data sent to remote device.
+    long long unsigned int sent_raw_data;
+    // Data sent with receipt acknowledgment from remote side
+    // Got from usbl. How to reset it is unknown.
+    long long unsigned int delivered_raw_data;
+    // Data received from remote device.
+    long long unsigned int received_raw_data;
 };
 
 /** IN NOISE state

--- a/src/UsblParser.cpp
+++ b/src/UsblParser.cpp
@@ -342,6 +342,18 @@ double UsblParser::getDouble(string const &buffer)
     return stod(buffer_tmp, &sz);
 }
 
+// Get a long long unsigned int from a response buffer in COMMAND mode.
+long long unsigned int UsblParser::getULLongInt(string const &buffer)
+{
+    long long unsigned int value;
+    string buffer_tmp = buffer;
+    boost::algorithm::trim_if(buffer_tmp, boost::is_any_of("[*]"));
+    stringstream ss(buffer_tmp);
+    if (!(ss >> value))
+        throw ParseError("UsblParser.cpp getULLongInt. Expected an long long unsigned integer response, but read \"" + printBuffer(buffer) + "\"");
+    return value;
+}
+
 // Parse AcousticConnection Status of underwater link.
 AcousticConnection UsblParser::parseConnectionStatus (string const &buffer)
 {

--- a/src/UsblParser.hpp
+++ b/src/UsblParser.hpp
@@ -176,6 +176,14 @@ public:
      */
     double getDouble(string const &buffer);
 
+    /** Get a long long unsigned int from a response buffer in COMMAND mode.
+     *
+     * Throw ou_of_range in case of failure.
+     * @param buffer with a counter number as response.
+     * @return long long unsigned int number.
+     */
+    long long unsigned int getULLongInt(string const &buffer);
+
     /** Parse AcousticConnection Status of underwater link.
      *
      * Throw ParseError in case of failure.


### PR DESCRIPTION
Include counters for sent, received and delivered raw data.

Found that usbl provides a counter of raw data delivered.
It will be possible to know if a packet (in auv_uwmodem_data) was delivered by counting the bytes delivered individually.  