### PR TITLE
Fix bug in getting settings.

### DIFF
--- a/src/UsblParser.cpp
+++ b/src/UsblParser.cpp
@@ -428,7 +428,13 @@ DeviceSettings UsblParser::parseCurrentSettings (string const &buffer)
     for(size_t i=0; i < splitted.size(); i++ )
     {
         vector<string> splitted2 = splitValidate(splitted.at(i), ":", 2);
-        if(splitted2.at(0) == "Gain")
+        if(splitted2.at(0) == "Source Level Control")
+            // This setting is dealt separately.
+            continue;
+        else if(splitted2.at(0) == "Source Level")
+            // This setting is dealt separately.
+            continue;
+        else if(splitted2.at(0) == "Gain")
         {
             if(atoi(splitted2.at(1).c_str()) == 0)
                 settings.lowGain = false;


### PR DESCRIPTION
Consider the settings that doesn't make part of DeviceSettings.

@saarnold: It should fix the bug. It came from here https://github.com/Brazilian-Institute-of-Robotics/drivers-usbl_evologics/commit/6d2ea6cf42a8f627074a5ed2a12cc9f5761e84f9. 
